### PR TITLE
Verbose dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ before_script:
 
 script: 
     - make -j2
-    - make test
+    - ctest -V
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
 
 test_script:
 # - echo %PATH%
-- ctest -v --build-config %CONFIGURATION%
+- ctest -V --build-config %CONFIGURATION%
 
 # on_finish:
 # - ps: '# $blockRdp = $true; iex ((new-object net.webclient).DownloadString(''https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1''))'

--- a/src/DepPoco.cpp
+++ b/src/DepPoco.cpp
@@ -32,7 +32,9 @@
 #include "Poco/Version.h"
 #endif
 
+#if ( POCO_VERSION >= 0x01030602 )
 #include "Poco/Environment.h"
+#endif
 #include "Poco/NumberFormatter.h"
 
 #include "DepPoco.h"
@@ -71,7 +73,13 @@ std::string DepPoco::buildTimeVersion()
 
 std::string DepPoco::runTimeVersion()
 {
+// Poco::Environment::libraryVersion introduced in 1.3.6p2
+#if ( POCO_VERSION >= 0x01030602 )
     return parseVersion(Poco::Environment::libraryVersion());
+#else
+	return "Poco build time version < 1.3.6p2. "
+           "Unable to get the runtime version..."
+#endif
 }
 
 std::string DepPoco::parseVersion(Poco::UInt32 ver)

--- a/src/DepPoco.cpp
+++ b/src/DepPoco.cpp
@@ -77,8 +77,8 @@ std::string DepPoco::runTimeVersion()
 #if ( POCO_VERSION >= 0x01030602 )
     return parseVersion(Poco::Environment::libraryVersion());
 #else
-	return "Poco build time version < 1.3.6p2. "
-           "Unable to get the runtime version..."
+    return "Poco build time version < 1.3.6p2. "
+           "Unable to get the runtime version..."; 
 #endif
 }
 

--- a/src/DepPoco.cpp
+++ b/src/DepPoco.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file	src/DepPoco.cpp
+ * @date	nov. 2015
+ * @author	PhRG - opticalp.fr
+ */
+
+/*
+ Copyright (c) 2015 Ph. Renaud-Goud / Opticalp
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+
+// since 1.4.0, Poco defines its version in Version.h
+#ifdef POCO_VERSION_H
+#include "Poco/Version.h"
+#endif
+
+#include "Poco/Environment.h"
+#include "Poco/NumberFormatter.h"
+
+#include "DepPoco.h"
+
+std::string DepPoco::name()
+{
+    return "POCO";
+}
+
+std::string DepPoco::description()
+{
+    return "\"POrtable COmponents\" are modern, "
+            "powerful open source C++ class libraries "
+            "for building network- and internet-based applications "
+            "that run on desktop, server, mobile and embedded systems.";
+
+    // TODO: describe components here?
+}
+
+std::string DepPoco::URL()
+{
+    return "http://pocoproject.org/";
+}
+
+std::string DepPoco::license()
+{
+    return "Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH. "
+           "and Contributors. \n"
+           "SPDX-License-Identifier: BSL-1.0";
+}
+
+std::string DepPoco::buildTimeVersion()
+{
+    return parseVersion(POCO_VERSION);
+}
+
+std::string DepPoco::runTimeVersion()
+{
+    return parseVersion(Poco::Environment::libraryVersion());
+}
+
+std::string DepPoco::parseVersion(Poco::UInt32 ver)
+{
+    std::string pocoV;
+
+    int patch = (ver >> 8) & 0xFF;
+    int minor = (ver >> 16) & 0xFF;
+    int major = (ver >> 24) & 0xFF;
+
+    pocoV = Poco::NumberFormatter::format(major) + "."
+          + Poco::NumberFormatter::format(minor) + "."
+          + Poco::NumberFormatter::format(patch) ;
+
+    switch (ver & 0xF0)
+    {
+    case 0xA0:
+        pocoV = pocoV + "(alpha" + Poco::NumberFormatter::format(ver & 0x0F) + ")";
+        break;
+    case 0xB0:
+        pocoV = pocoV + "(beta" + Poco::NumberFormatter::format(ver & 0x0F) + ")";
+        break;
+    case 0xD0:
+        pocoV = pocoV + "(dev" + Poco::NumberFormatter::format(ver & 0x0F) + ")";
+        break;
+    case 0x00:
+        if ((ver & 0x0F) == 0 )
+            pocoV = pocoV + "(stable)";
+        // else: unknown
+        break;
+    default:
+        // unknown
+        break;
+    }
+
+    return pocoV;
+}

--- a/src/DepPoco.h
+++ b/src/DepPoco.h
@@ -1,0 +1,58 @@
+/**
+ * @file	src/DepPoco.h
+ * @date	nov. 2015
+ * @author	PhRG - opticalp.fr
+ */
+
+/*
+ Copyright (c) 2015 Ph. Renaud-Goud / Opticalp
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#ifndef SRC_DEPPOCO_H_
+#define SRC_DEPPOCO_H_
+
+#include "Poco/Types.h"
+
+#include "Dependency.h"
+
+/**
+ * DepPoco
+ *
+ * Description of Poco external dependency.
+ * Only implement parent abstract methods.
+ */
+class DepPoco: public Dependency
+{
+public:
+    DepPoco() { }
+
+    std::string name();
+    std::string description();
+    std::string URL();
+    std::string license();
+    std::string buildTimeVersion();
+    std::string runTimeVersion();
+
+private:
+    std::string parseVersion(Poco::UInt32 ver);
+};
+
+#endif /* SRC_DEPPOCO_H_ */

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -1,0 +1,68 @@
+/**
+ * @file	src/Dependency.h
+ * @date	nov. 2015
+ * @author	PhRG - opticalp.fr
+ */
+
+/*
+ Copyright (c) 2015 Ph. Renaud-Goud / Opticalp
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#ifndef SRC_DEPENDENCY_H_
+#define SRC_DEPENDENCY_H_
+
+#include <string>
+
+/**
+ * Dependency
+ *
+ * Base class to be used to describe external dependencies (libraries)
+ */
+class Dependency
+{
+public:
+    Dependency() { }
+
+    virtual std::string name()=0;
+    virtual std::string description()=0;
+    virtual std::string URL()=0;
+    virtual std::string license()=0;
+
+    /**
+     * Version of the library as it was at build time
+     *
+     * Usually got from the headers or any cmake-related feature
+     */
+    virtual std::string buildTimeVersion()=0;
+
+    /**
+     * Version of the library as it is at run time
+     *
+     * It provides a mean to verify that the run time version
+     * is the same than the build time version.
+     *
+     * This function should call a function in the external library
+     * and not rely on headers (!)
+     */
+    virtual std::string runTimeVersion()=0;
+};
+
+#endif /* SRC_DEPENDENCY_H_ */

--- a/src/MainApplication.cpp
+++ b/src/MainApplication.cpp
@@ -1,5 +1,5 @@
 /**
- * @file	MainApplication.cpp
+ * @file	src/MainApplication.cpp
  * @date	nov. 2015
  * @author	PhRG - opticalp.fr
  *

--- a/src/MainApplication.cpp
+++ b/src/MainApplication.cpp
@@ -47,6 +47,8 @@ MainApplication::MainApplication(): _helpRequested(false)
 {
     // Application::instance().addSubsystem(new MySubsystem); //template
 
+    // deps.append(new MyDependency); //template
+
 }
 
 void MainApplication::initialize(Application& self)

--- a/src/MainApplication.h
+++ b/src/MainApplication.h
@@ -33,6 +33,7 @@
 #include "Poco/Util/Application.h"
 #include "Poco/Util/OptionSet.h"
 
+#include "Dependency.h"
 
 /**
  * MainApplication
@@ -139,6 +140,7 @@ protected:
 
 private:
     bool _helpRequested; ///< flag to stop processing if help is requested
+    std::vector<Dependency*> deps; ///< dependencies descriptors
 };
 
 #endif /* SRC_MAINAPPLICATION_H_ */

--- a/src/MainApplication.h
+++ b/src/MainApplication.h
@@ -53,9 +53,16 @@ public:
      * Default constructor
      *
      *  - Add new subsystems
-     *  - TODO: list dependencies
+     *  - create dependency list
      */
     MainApplication();
+
+    /**
+     * Default destructor
+     *
+     * Empty dependency list
+     */
+    virtual ~MainApplication();
 
 protected:
     /**
@@ -118,13 +125,6 @@ protected:
      * TODO: dynamic semantic version using cmake, git and CI
      */
     std::string version();
-
-    /**
-     * Get POCO (external dependency) version
-     *
-     * TODO: get it out of this class
-     */
-    std::string pocoVersion();
 
     /**
      * The application's main logic.

--- a/src/MainApplication.h
+++ b/src/MainApplication.h
@@ -1,5 +1,5 @@
 /**
- * @file	MainApplication.h
+ * @file	src/MainApplication.h
  * @date	nov. 2015
  * @author	PhRG - opticalp.fr
  *
@@ -138,7 +138,7 @@ protected:
     void printProperties(const std::string& base);
 
 private:
-    bool _helpRequested;
+    bool _helpRequested; ///< flag to stop processing if help is requested
 };
 
 #endif /* SRC_MAINAPPLICATION_H_ */


### PR DESCRIPTION
Introduction of the `Dependency` class and one sample child: `DepPoco`. 
 - Usage in `MainApplication` via `MainApplication::about()`. 
 - Storage of the dependency descriptions (Dependency children) in `MainApplication::deps`.

Configuring appveyor and travis CI to display the test results. 

We are not able to export the ctest results to "tests" in appveyor. Should be done with xml export and xunit integration. Without success yet. 