### PR TITLE
App veyor python import error

### DIFF
--- a/CI/appveyor/install_dependencies.bat
+++ b/CI/appveyor/install_dependencies.bat
@@ -6,7 +6,6 @@ REM @license MIT
 REM Install dependencies:
 REM  - build POCO from latest git release. 
 
-
 set CURRENT_DIR=%CD%
 REM echo "current dir is %CURRENT_DIR%"
 
@@ -46,3 +45,10 @@ REM echo "Poco install done. "
 
 REM %PATH% has to be modified to take into account poco .dlls
 cd %CURRENT_DIR%
+
+REM fix python configuration for 2.7.11
+if "%ARCH%"=="Win64" (
+  set PYTHONHOME=C:\Python27-x64
+) else (
+  set PYTHONHOME=C:\Python27
+)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,17 +19,21 @@ init:
 
 environment:
   matrix:
-  - GENERATOR: Visual Studio 11 2012 Win64
   - GENERATOR: Visual Studio 11 2012
-#  - GENERATOR: Visual Studio 12 2013 Win64
+    ARCH: Win64
+  - GENERATOR: Visual Studio 11 2012
 #  - GENERATOR: Visual Studio 12 2013
-  - GENERATOR: Visual Studio 14 2015 Win64
+#    ARCH: Win64
+#  - GENERATOR: Visual Studio 12 2013
+  - GENERATOR: Visual Studio 14 2015
+    ARCH: Win64
   - GENERATOR: Visual Studio 14 2015
 #  - GENERATOR: MinGW Makefiles  # poco is not compiling with this yet... (1.6.0)
 
 install:
 - if "%GENERATOR%"=="MinGW Makefiles" ( set SH_COMMAND=gulash.exe ) else ( set SH_COMMAND=sh.exe )
 - if "%GENERATOR%"=="MinGW Makefiles" ( move "%PROGRAMFILES%\Git\usr\bin\sh.exe" "%PROGRAMFILES%\Git\usr\bin\%SH_COMMAND%" )
+- if NOT [%ARCH%] == [] ( set GENERATOR=%GENERATOR% %ARCH%)
 - call %APPVEYOR_BUILD_FOLDER%\CI\appveyor\install_dependencies.bat # install poco
 
 before_build:


### PR DESCRIPTION
Bypass bug introduced in appVeyor with python 2.7.11 install: importError site.py
It meant: issue with PYTHONHOME