### PR TITLE
Fix new data automatic releaseData issue in InPortLockUnlock

### DIFF
--- a/src/DemoModuleSeqAccu.cpp
+++ b/src/DemoModuleSeqAccu.cpp
@@ -84,6 +84,8 @@ void DemoModuleSeqAccu::process(InPortLockUnlock& inPortsAccess,
         return; // data not up to date
     }
 
+    inPortsAccess.processing();
+
     if (attr.isStartSequence())
     {
         accumulator.clear();

--- a/src/DemoModuleSeqMax.cpp
+++ b/src/DemoModuleSeqMax.cpp
@@ -83,6 +83,8 @@ void DemoModuleSeqMax::process(InPortLockUnlock& inPortsAccess,
         return; // data not up to date
     }
 
+    inPortsAccess.processing();
+
     if (attr.isStartSequence())
     {
         tmpMax = *pData;

--- a/src/InPort.h
+++ b/src/InPort.h
@@ -103,6 +103,8 @@ public:
      */
     void hold(bool status = true) { held = status; }
 
+    bool isNew() { return !used; }
+
 private:
     /**
      * Set the source port
@@ -152,8 +154,6 @@ private:
      * when new data is available, just before the push.
      */
     void setNew(bool value = true);
-
-    bool isNew() { return !used; }
 
     /**
      * Determine if the data of this port are up to date


### PR DESCRIPTION
see PR #20

in InPortLockUnlock, with multiple input data, it was not possible to leave process() without releasing the input data, even if it was new... although this feature is widely used with more than one input port.