### PR TITLE
Try to fix Travis #577.4 error

### DIFF
--- a/src/core/MergeableTask.cpp
+++ b/src/core/MergeableTask.cpp
@@ -77,7 +77,7 @@ void MergeableTask::cancel()
 	}
 	else
 	{
-	    state = TASK_CANCELLING;
+	    setState(TASK_CANCELLING);
 	    cancelEvent.set();
 	    if (pOwner)
 	        pOwner->taskCancelled(this);
@@ -141,7 +141,7 @@ void MergeableTask::run()
 
 void MergeableTask::taskFinishedBroadcast(TaskManager* pTm)
 {
-	state = TASK_FINISHED;
+	setState(TASK_FINISHED);
 	if (pTm)
 		pTm->taskFinished(this);
 


### PR DESCRIPTION
Deadlock while canceling. It seems to be bound to the state change of mergeable tasks. 